### PR TITLE
fix: mark api-key as isSecret in config_schema

### DIFF
--- a/cmd/baton-litmos/config.go
+++ b/cmd/baton-litmos/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	apiKeyField       = field.StringField("api-key", field.WithDescription(`API Key`), field.WithRequired(true))
+	apiKeyField       = field.StringField("api-key", field.WithDescription(`API Key`), field.WithRequired(true), field.WithIsSecret(true))
 	sourceField       = field.StringField("source", field.WithDescription(`Source`), field.WithRequired(true))
 	limitCoursesField = field.StringSliceField("limited-courses", field.WithDescription(`Limit imported sources to a specific list by Course ID`), field.WithRequired(false))
 )


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->