### PR TITLE
docs: correct product name to SAP Litmos

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Set up a Litmos connector"
-og:title: "Set up a Litmos connector"
-description: "C1 provides identity governance and just-in-time provisioning for Litmos. Integrate your Litmos instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Litmos. Integrate your Litmos instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-sidebarTitle: "Litmos"
+title: "Set up an SAP Litmos connector"
+og:title: "Set up an SAP Litmos connector"
+description: "C1 provides identity governance and just-in-time provisioning for SAP Litmos. Integrate your SAP Litmos instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance and just-in-time provisioning for SAP Litmos. Integrate your SAP Litmos instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+sidebarTitle: "SAP Litmos"
 ---
 
 ## Capabilities
@@ -36,9 +36,9 @@ Carefully copy and save the API key.
 </Step>
 </Steps> 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
-## Configure the Litmos connector
+## Configure the SAP Litmos connector
 
 <Warning>
 To complete this task, you'll need:
@@ -95,11 +95,11 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Litmos connector is now pulling access data into C1.
+**Done.** Your SAP Litmos connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
-**Follow these instructions to use the Litmos connector, hosted and run in your own environment.**
+**Follow these instructions to use the SAP Litmos connector, hosted and run in your own environment.**
 
 When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with C1, automatically syncing and uploading data at regular intervals. This data is immediately available in the C1 UI for access reviews and access requests.
 
@@ -212,10 +212,10 @@ spec:
 Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
 </Step>
 <Step>
-Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Litmos connector to. Litmos data should be found on the **Entitlements** and **Accounts** tabs.
+Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the SAP Litmos connector to. Litmos data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
 
-**That's it!** Your Litmos connector is now pulling access data into C1.
+**Done.** Your SAP Litmos connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
Corrects all instances of "Litmos" to "SAP Litmos" throughout the connector documentation to match the official product name and the published docs site.